### PR TITLE
 [Feat] - 마이페이지 프로필 이미지 수정하기 #72

### DIFF
--- a/src/app/(clrm)/mypage/page.tsx
+++ b/src/app/(clrm)/mypage/page.tsx
@@ -4,8 +4,9 @@ import TeacherMyPageTab from '@/components/mypage/teacher/TeacherMyPageTab';
 
 // 일단 임시로 생성 userId : 로그인한 사람의 user_id => zustand로 전역관리
 // 실제 로그인한 사람의 user_id가 들어가야함!
-// export const userId = '423e4567-e89b-12d3-a456-426614174004'; // admin : true인 사람 (선생님)
-export const userId = '523e4567-e89b-12d3-a456-426614174005'; // admin : false인 사람 (수강생)
+export const userId = '423e4567-e89b-12d3-a456-426614174004'; // admin : true인 사람 (선생님)
+// export const userId = '523e4567-e89b-12d3-a456-426614174005'; // admin : false인 사람 (수강생)
+// export const userId = '5c6c34bf-1a4d-421c-adf4-8da1a349a821'; // (미주님)
 
 const MyPage = async () => {
   // 일단 teacher :  teacher = true / student = false 이라고 가정

--- a/src/app/api/mypage/user-api.ts
+++ b/src/app/api/mypage/user-api.ts
@@ -31,7 +31,10 @@ export const getUserInfo = async () => {
     console.error(error);
   }
 
-  useUserStore.getState().setUserInfo(userInfo);
+  // zustand에 상태 업데이트
+  if (userInfo) {
+    useUserStore.getState().setUserInfo(userInfo);
+  }
 
   return userInfo;
 };

--- a/src/app/api/mypage/user-api.ts
+++ b/src/app/api/mypage/user-api.ts
@@ -1,12 +1,13 @@
-import { PostgrestMaybeSingleResponse } from '@supabase/supabase-js';
+import { PostgrestMaybeSingleResponse, PostgrestResponse, PostgrestSingleResponse } from '@supabase/supabase-js';
 import { supabase } from '../supabase/supabase';
-import { UpdateTeacherInfoType, UpdateUserInfoType, UserType } from '@/types/user';
+import { UpdateTeacherInfoType, UpdateUserInfoType, UserInfoType, UserType } from '@/types/user';
 import { userId } from '@/app/(clrm)/mypage/page';
+import { useUserStore } from '@/store/UserInfoStore';
 
 // User가 선생님인지 수강생인지 구분 : isTeacher 값 불러오기
 export const getUserRole = async ({ userId }: { userId: string }) => {
   const { data: userRole, error }: PostgrestMaybeSingleResponse<UserType> = await supabase
-    .from('user')
+    .from('users')
     .select('isTeacher')
     .eq('user_id', userId)
     .single();
@@ -20,9 +21,9 @@ export const getUserRole = async ({ userId }: { userId: string }) => {
 
 // User(선생님/수강생) 정보 불러오기
 export const getUserInfo = async () => {
-  const { data: userInfo, error }: PostgrestMaybeSingleResponse<UserType> = await supabase
-    .from('user')
-    .select('nickname, email, password, profile_image')
+  const { data: userInfo, error }: PostgrestMaybeSingleResponse<UserInfoType> = await supabase
+    .from('users')
+    .select('nickname, email, profile_image')
     .eq('user_id', userId)
     .single();
 
@@ -30,12 +31,17 @@ export const getUserInfo = async () => {
     console.error(error);
   }
 
+  useUserStore.getState().setUserInfo(userInfo);
+
   return userInfo;
 };
 
 // User(선생님/수강생) 정보 수정하기 : supabase에 update
-export const updateUserInfo = async ({ newNickname }: UpdateUserInfoType) => {
-  const { data, error } = await supabase.from('user').update({ nickname: newNickname }).eq('user_id', userId);
+export const updateUserInfo = async ({ newNickname, newProfileImage }: UpdateUserInfoType) => {
+  const { data, error } = await supabase
+    .from('users')
+    .update({ nickname: newNickname, profile_image: newProfileImage })
+    .eq('user_id', userId);
   if (error) {
     console.error(error);
   }
@@ -45,7 +51,7 @@ export const updateUserInfo = async ({ newNickname }: UpdateUserInfoType) => {
 // User(선생님/수강생) nickname 중복 확인하기
 export const checkUserNickname = async ({ newNickname }: Pick<UpdateUserInfoType, 'newNickname'>) => {
   const { data, error } = await supabase
-    .from('user')
+    .from('users')
     .select('nickname')
     .not('user_id', 'eq', userId)
     .eq('nickname', newNickname);
@@ -61,7 +67,7 @@ export const checkUserNickname = async ({ newNickname }: Pick<UpdateUserInfoType
 // User(선생님/수강생) 정보 불러오기
 export const getTeacherInfo = async () => {
   const { data: teacherInfo, error }: PostgrestMaybeSingleResponse<UserType> = await supabase
-    .from('user')
+    .from('users')
     .select('job, field, bank, account')
     .eq('user_id', userId)
     .single();
@@ -69,7 +75,7 @@ export const getTeacherInfo = async () => {
   if (error) {
     console.error(error);
   }
-  // console.log('teacherInfo', teacherInfo);
+
   return teacherInfo;
 };
 
@@ -81,7 +87,7 @@ export const updateTeacherInfo = async ({
   account
 }: UpdateTeacherInfoType) => {
   const { data, error } = await supabase
-    .from('user')
+    .from('users')
     .update({ job: newSelectedJob, field: newSelectedField, bank: selectedBank, account: account })
     .eq('user_id', userId);
   if (error) {

--- a/src/components/mypage/EditProfile.tsx
+++ b/src/components/mypage/EditProfile.tsx
@@ -18,6 +18,7 @@ const EditProfile = () => {
   });
 
   const [newNickname, setNewNickname] = useState('');
+  const [newProfileImage, setNewProfileImage] = useState('');
   const [isEditing, setIsEditing] = useState(false); // 수정된 사항 확인 여부
   const [isAvailableNickname, setIsAvailableNickname] = useState(true); // 닉네임 중복 여부 상태 업데이트
   const [isActiveBtn, setIsActiveBtn] = useState(false); // 수정 완료시 버튼 활성화 상태
@@ -25,6 +26,7 @@ const EditProfile = () => {
   useEffect(() => {
     if (userInfo) {
       setNewNickname(userInfo.nickname || '');
+      setNewProfileImage(userInfo.profile_image || '');
     }
   }, [userInfo]);
 
@@ -42,7 +44,8 @@ const EditProfile = () => {
 
   // 유저 정보 수정하기 : useMutation
   const { mutate: updateUserInfoMutation } = useMutation({
-    mutationFn: ({ newNickname }: UpdateUserInfoType) => updateUserInfo({ newNickname }),
+    mutationFn: ({ newNickname, newProfileImage }: UpdateUserInfoType) =>
+      updateUserInfo({ newNickname, newProfileImage }),
     onSuccess: () => {
       queryClient.invalidateQueries({
         queryKey: ['user']
@@ -55,18 +58,20 @@ const EditProfile = () => {
   const handleOnClickEditProfileBtn = () => {
     // 수정된 사항이 없는 경우
     const isNicknameChanged = newNickname !== userInfo?.nickname;
+    // console.log('isNicknameChanged', isNicknameChanged);
+    const isProfileImageChanged = newProfileImage != userInfo?.profile_image;
 
-    if (!isNicknameChanged) {
+    if (!isNicknameChanged && !isProfileImageChanged) {
       alert('수정 사항이 없습니다.');
-
-      if (!isAvailableNickname) {
-        alert('이미 사용 중인 닉네임입니다. 다른 닉네임을 다시 입력해주세요.');
-      }
+      return;
+    }
+    if (!isAvailableNickname) {
+      alert('이미 사용 중인 닉네임입니다. 다른 닉네임을 다시 입력해주세요.');
       return;
     }
 
     // 수정된 사항이 있는 경우
-    updateUserInfoMutation({ newNickname });
+    updateUserInfoMutation({ newNickname, newProfileImage });
     alert('프로필 수정이 완료되었습니다.');
   };
 
@@ -78,6 +83,7 @@ const EditProfile = () => {
       if (confirm) {
         setIsEditing(false);
         setNewNickname(userInfo?.nickname || '');
+        setNewProfileImage(userInfo?.profile_image || '');
         setIsAvailableNickname(true);
         setIsActiveBtn(false);
       }
@@ -94,7 +100,11 @@ const EditProfile = () => {
 
   return (
     <div className="flex">
-      <EditProfileImage userInfo={userInfo} />
+      <EditProfileImage
+        newProfileImage={newProfileImage}
+        setNewProfileImage={setNewProfileImage}
+        isEditing={isEditing}
+      />
       <div className="flex flex-col">
         <div className="flex flex-col">
           <div className="m-4 p-4 gap-4">
@@ -131,13 +141,9 @@ const EditProfile = () => {
               수정하기
             </button>
           )}
-          {isEditing ? (
-            <button onClick={handleOnClickCancleBtn} className="btn w-[100px]  bg-point-color text-white">
-              취소하기
-            </button>
-          ) : (
-            ''
-          )}
+          <button onClick={handleOnClickCancleBtn} className="btn w-[100px]  bg-point-color text-white">
+            취소하기
+          </button>
         </div>
       </div>
     </div>

--- a/src/components/mypage/EditProfileImage.tsx
+++ b/src/components/mypage/EditProfileImage.tsx
@@ -1,13 +1,15 @@
-import { UpdateProfileImageType, UserInfoType, UserType } from '@/types/user';
-import Image from 'next/image';
-import { ChangeEvent, ChangeEventHandler, MutableRefObject, useRef, useState } from 'react';
-import BasicProfileImage from '../../../public/profile-image.png';
-import Link from 'next/link';
 import { supabase } from '@/app/api/supabase/supabase';
+import { UpdateUserInfoType, UserType } from '@/types/user';
+import Image from 'next/image';
+import { ChangeEvent, Dispatch, SetStateAction, useRef, useState } from 'react';
 
-const EditProfileImage = ({ userInfo }: { userInfo: UserType }) => {
-  const [updateProfileImage, setUpdateProfileImage] = useState(userInfo?.profile_image);
+interface EditProfileImageProps {
+  newProfileImage: string;
+  setNewProfileImage: Dispatch<SetStateAction<string>>;
+  isEditing: boolean;
+}
 
+const EditProfileImage = ({ newProfileImage, setNewProfileImage, isEditing }: EditProfileImageProps) => {
   const fileInput = useRef<HTMLInputElement | null>(null);
 
   // 프로필 이미지 수정 버튼 클릭
@@ -24,9 +26,9 @@ const EditProfileImage = ({ userInfo }: { userInfo: UserType }) => {
       console.error('파일 업로드 실패 :', error);
       throw error;
     } else {
-      const url = `${process.env.NEXT_PUBLIC_SUPABASE_URL}/storage/v1/object/public/${data.path}`;
-      console.log('url', url);
-      return setUpdateProfileImage(url);
+      const url = `${process.env.NEXT_PUBLIC_SUPABASE_URL}/storage/v1/object/public/profileImages/${data.path}`;
+      // console.log('url', url);
+      return setNewProfileImage(url);
     }
   };
 
@@ -37,18 +39,14 @@ const EditProfileImage = ({ userInfo }: { userInfo: UserType }) => {
       return;
     }
 
-    const imgUrl = URL.createObjectURL(file);
-    setUpdateProfileImage(imgUrl);
-    console.log('imgUrl', imgUrl);
-
-    // uploadProfileImage(file);
+    uploadProfileImage(file);
   };
 
   return (
     <div>
       <div className="flex flex-col items-center p-4 gap-4">
         <Image
-          src={updateProfileImage}
+          src={newProfileImage}
           width={100}
           height={100}
           className="rounded-full"
@@ -58,7 +56,6 @@ const EditProfileImage = ({ userInfo }: { userInfo: UserType }) => {
         <input
           type="file"
           name="image_URL"
-          id="input-file"
           accept="image/*" // 모든 이미지 파일 형식 가능
           style={{
             display: 'none'
@@ -67,9 +64,13 @@ const EditProfileImage = ({ userInfo }: { userInfo: UserType }) => {
           onChange={handleOnChangeImage}
         />
       </div>
-      <button className="btn p-4 bg-point-color text-white" onClick={handleOnClickEditImageBtn}>
-        프로필 이미지 변경
-      </button>
+      {isEditing ? (
+        <button className="btn p-4 bg-point-color text-white" onClick={handleOnClickEditImageBtn}>
+          프로필 이미지 변경
+        </button>
+      ) : (
+        ''
+      )}
     </div>
   );
 };

--- a/src/components/mypage/teacher/EditTeacherInfo.tsx
+++ b/src/components/mypage/teacher/EditTeacherInfo.tsx
@@ -7,6 +7,7 @@ import { useQuery } from '@tanstack/react-query';
 import { getTeacherInfo, updateTeacherInfo } from '@/app/api/mypage/user-api';
 import { userId } from '@/app/(clrm)/mypage/page';
 import { FieldType, JobType } from '@/types/authUser/authUser';
+import { useUserStore } from '@/store/UserInfoStore';
 
 const EditTeacherInfo = () => {
   const [isEditing, setIsEditing] = useState(false);
@@ -15,6 +16,8 @@ const EditTeacherInfo = () => {
   const [newSelectedField, setNewSelectedField] = useState('');
   const [selectedBank, setSelectedBank] = useState('');
   const [account, setAccount] = useState('');
+
+  const { userInfo } = useUserStore();
 
   const { data: teacherInfo, isPending } = useQuery({
     queryKey: ['user', userId],
@@ -108,7 +111,7 @@ const EditTeacherInfo = () => {
   return (
     <div className="flex">
       <div className="flex flex-col items-center p-4 gap-4">
-        <Image src={BasicProfileImage} alt="기본 프로필 이미지" width={100} height={100} />
+        <img src={userInfo?.profile_image} alt="기본 프로필 이미지" width={100} height={100} className="rounded-full" />
       </div>
       <div className="flex flex-col">
         <div className="flex flex-col">

--- a/src/store/UserInfoStore.ts
+++ b/src/store/UserInfoStore.ts
@@ -1,0 +1,14 @@
+import { UserInfoType, UserType } from '@/types/user';
+import { create } from 'zustand';
+
+interface UserState {
+  userInfo: UserInfoType | null;
+  setUserInfo: (userInfo: UserInfoType) => void;
+}
+
+export const useUserStore = create<UserState>()((set) => ({
+  userInfo: null,
+  setUserInfo: (getUserInfo) => {
+    set(() => ({ userInfo: getUserInfo }));
+  }
+}));

--- a/src/types/user.ts
+++ b/src/types/user.ts
@@ -22,6 +22,7 @@ export interface UserInfoType {
 // 수정된 닉네임 type
 export interface UpdateUserInfoType {
   newNickname: string;
+  newProfileImage: string;
 }
 
 // 수정된 선생님 정보 type


### PR DESCRIPTION
## 📌 관련 이슈
<!-- 관련 있는 이슈의 번호(#000)를 적어주세요.
close / closed 등의 키워드를 이슈번호 앞에 사용하면, Merge할 때 해당 이슈가 자동으로 close 됩니다. -->
closed #72 

## Task LIST
<!-- 자신이 수행한 작업 목록을 작성해주세요. -->
- [x] 프로필 이미지 user 테이블에 profile_image에 업데이트
- [x] 유저 정보 zustand로 관리 : user nickname, profile_image 다른 곳에서도 사용할 수 있도록..!

## ✨ 개발 주요 내용
<!-- 모두에게 적용되는 코드를 작업했거나, 중요한 내용이 있는 경우, 또는 개발한 주요 코드를 작성해주세요. -->
### zustand로 user 정보 전역으로 상태관리하고 있습니다. 
```ts
/* src > store > UseUserStore.ts */

import { UserInfoType } from '@/types/user';
import { create } from 'zustand';

interface UserState {
  userInfo: UserInfoType | null;
  setUserInfo: (userInfo: UserInfoType) => void;
}

export const useUserStore = create<UserState>()((set) => ({
  userInfo: null,
  setUserInfo: (getUserInfo) => {
    set(() => ({ userInfo: getUserInfo }));
  }
}));
```

로그인한 user 정보가 필요한 컴포넌트에서 useUserStore 호출해서 사용하시면, nickname, email, profile_image까지 사용가능합니다.

```ts
  const { userInfo } = useUserStore();
```

## 🛠️라이브러리 설치
<!-- 라이브러리 설치 시 작성해주세요. -->
```
- 라이브러리: 
- 설치 명령어: 
```

## 📸 스크린샷(선택)
<!-- 구현한 기능을 img나 gif로 올려주세요. -->
프로필 수정하기에서 변경한 프로필 이미지를 선생님 정보 수정하기에서 zustand로 user 정보 불러와서 사용하고 있습니다. 
<img width="689" alt="스크린샷 2024-04-03 오후 6 19 18" src="https://github.com/ClassRoom-Project/ClassRoom-Project/assets/154870548/9c59c30d-1aab-4a6c-8bf8-83d5e8bbf975">
<img width="700" alt="image" src="https://github.com/ClassRoom-Project/ClassRoom-Project/assets/154870548/d1096d7a-165f-48bf-84ce-f457c0adcc55">


## Trouble Shooting(선택)
<!-- Trouble Shooting한 내역이 있었다면 공유해주세요. -->
```
```

## 📚 참고사항 혹은 궁금한 사항
<!-- 참고해야 할 사항이 있거나 궁금한 사항이 있는 경우 작성해주세요.
(ex. react-query 라이브러리를 추가했습니다. pull 받으신 후에 npm i / yarn 입력해주세요.)
(ex. query를 어떻게 사용해야 하는지 모르겠습니다. 방법 좀 공유해주세요.) -->

브랜치 번호가 #76 쓰고 있어서 그게 이 티켓인줄 알았는데 #72 이었네요... 번호 헷갈려서 #76 달아서 commit 올린게 다 #72 티켓 내용입니다... #76 브랜치에서 이어서 #76 티켓 마무리하고 issue 닫을게요...!